### PR TITLE
Allow tests on master

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,11 @@
 name: run-tests
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should fix the 'coverage unknown' issue on the home page by allowing tests to run on push (to master) and when a pull request is created (to master).